### PR TITLE
trim the secret so no training spaces cause auth failure

### DIFF
--- a/socialauth/src/main/java/org/brickred/socialauth/SocialAuthConfig.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/SocialAuthConfig.java
@@ -314,9 +314,10 @@ public class SocialAuthConfig implements Serializable {
 			String cKey = applicationProperties.getProperty(value
 					+ ".consumer_key");
 			String cSecret = applicationProperties.getProperty(value
-					+ ".consumer_secret").trim();
+					+ ".consumer_secret");
 			if (cKey != null && cSecret != null) {
 				LOG.debug("Loading configuration for provider : " + key);
+ 				cSecret = cSecret.trim();
 				OAuthConfig conf = new OAuthConfig(cKey, cSecret);
 				conf.setId(key);
 				conf.setProviderImplClass(providersImplMap.get(key));


### PR DESCRIPTION
Trim the secret when read from the config. 

With googleplus I had a trailing space on the secret which caused a 400 error on access_token request.
