### PR TITLE
fix google plus expiration handling

### DIFF
--- a/socialauth/src/main/java/org/brickred/socialauth/oauthstrategy/OAuth2.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/oauthstrategy/OAuth2.java
@@ -208,7 +208,7 @@ public class OAuth2 implements OAuthStrategyBase {
 					accessToken = jObj.getString("access_token");
 				}
 				if (jObj.has("expires_in")) {
-					String str = jObj.getString("expires_in");
+					String str = jObj.get("expires_in").toString();
 					if (str != null && str.length() > 0) {
 						expires = Integer.valueOf(str);
 					}


### PR DESCRIPTION
Google plus token expiry is returned as:

"expires_in" : 3596

OAuth2 class only handles strings:

            if (jObj.has("expires_in")) {
                String str = jObj.getString("expires_in");
                if (str != null && str.length() > 0) {
                    expires = Integer.valueOf(str);
                }
            }

this code result in a exception being raised:
org.json.JSONException: JSONObject["expires_in"] not a string.

and ultimately fails with:

org.brickred.socialauth.exception.SocialAuthException: Unexpected auth response from https://accounts.google.com/o/oauth2/token


fix issue #30 