### PR TITLE
Update permission: read_stream -> user_posts

### DIFF
--- a/socialauth/src/main/java/org/brickred/socialauth/provider/FacebookImpl.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/provider/FacebookImpl.java
@@ -83,7 +83,7 @@ public class FacebookImpl extends AbstractProvider {
 	// set this to the list of extended permissions you want
 	private static final String[] AllPerms = new String[] { "publish_actions",
 			"public_profile", "email", "user_birthday", "user_location",
-			"user_photos", "user_friends", "read_stream" };
+			"user_photos", "user_friends", "user_posts" };
 	private static final String[] AuthPerms = new String[] { "email",
 			"user_birthday", "user_location", "public_profile" };
 


### PR DESCRIPTION
Permission **read_stream** was deprecated on Facebook API 2.4 (see [Facebook Platform Changelog](https://developers.facebook.com/docs/apps/changelog#v2_4_deprecations))

I've updated for [user_posts](https://developers.facebook.com/docs/apps/changelog#v2_3_new_features) permission.