### PR TITLE
Fix Facebook photo issue.

### DIFF
--- a/socialauth/src/main/java/org/brickred/socialauth/plugin/facebook/AlbumsPluginImpl.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/plugin/facebook/AlbumsPluginImpl.java
@@ -50,7 +50,7 @@ public class AlbumsPluginImpl implements AlbumsPlugin, Serializable {
 
 	private static final long serialVersionUID = 5350785649768508189L;
 	private static final String ALBUMS_URL = "https://graph.facebook.com/v2.2/me/albums";
-	private static final String ALBUM_PHOTOS_URL = "https://graph.facebook.com/v2.2/%1$s/photos";
+	private static final String ALBUM_PHOTOS_URL = "https://graph.facebook.com/v2.2/%1$s/photos?fields=names,link,picture,images";
 	private static final String ALBUM_COVER_URL = "https://graph.facebook.com/v2.2/%1$s/picture?access_token=%2$s";
 	private final Log LOG = LogFactory.getLog(this.getClass());
 


### PR DESCRIPTION
Although the request url points to fb graph 2.2 api, the response doesn't include the necessary fields by default (looks like response after 2.4 api). Therefore, parsing of photos will fail. Adding the fields explicitly can solve this issue.