### PR TITLE
Increase Facebook API version to 2.7

### DIFF
--- a/socialauth/src/main/java/org/brickred/socialauth/plugin/facebook/AlbumsPluginImpl.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/plugin/facebook/AlbumsPluginImpl.java
@@ -40,6 +40,8 @@ import org.brickred.socialauth.util.Response;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import static org.brickred.socialauth.provider.FacebookImpl.FB_API_URL;
+
 /**
  * Album Plugin implementation for Facebook
  * 
@@ -49,9 +51,9 @@ import org.json.JSONObject;
 public class AlbumsPluginImpl implements AlbumsPlugin, Serializable {
 
 	private static final long serialVersionUID = 5350785649768508189L;
-	private static final String ALBUMS_URL = "https://graph.facebook.com/v2.2/me/albums";
-	private static final String ALBUM_PHOTOS_URL = "https://graph.facebook.com/v2.2/%1$s/photos";
-	private static final String ALBUM_COVER_URL = "https://graph.facebook.com/v2.2/%1$s/picture?access_token=%2$s";
+	private static final String ALBUMS_URL = FB_API_URL + "/me/albums";
+	private static final String ALBUM_PHOTOS_URL = FB_API_URL + "/%1$s/photos?fields=names,link,picture,images";
+	private static final String ALBUM_COVER_URL = FB_API_URL + "/%1$s/picture?access_token=%2$s";
 	private final Log LOG = LogFactory.getLog(this.getClass());
 
 	private ProviderSupport providerSupport;

--- a/socialauth/src/main/java/org/brickred/socialauth/plugin/facebook/FeedPluginImpl.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/plugin/facebook/FeedPluginImpl.java
@@ -41,6 +41,8 @@ import org.brickred.socialauth.util.Response;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import static org.brickred.socialauth.provider.FacebookImpl.FB_API_URL;
+
 /**
  * Feed Plugin implementation for Facebook
  * 
@@ -50,7 +52,7 @@ import org.json.JSONObject;
 public class FeedPluginImpl implements FeedPlugin, Serializable {
 
 	private static final long serialVersionUID = 2108503235436046045L;
-	private static final String FEED_URL = "https://graph.facebook.com/v2.2/me/feed";
+	private static final String FEED_URL = FB_API_URL + "/me/feed?fields=from,message,story,name,caption,description,picture,created_time";
 	private static final DateFormat dateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'hh:mm:ssz");
 	private final Log LOG = LogFactory.getLog(FeedPluginImpl.class);

--- a/socialauth/src/main/java/org/brickred/socialauth/provider/FacebookImpl.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/provider/FacebookImpl.java
@@ -63,19 +63,16 @@ import org.json.JSONObject;
  * 
  */
 public class FacebookImpl extends AbstractProvider {
-
 	private static final long serialVersionUID = 8644510564735754296L;
-	/* Added by tanmoy-git
-	 * Profile fields are necessary for v2.4 API and above as by default it just gives the id and name
-	 *Removing the version, as from fb API docs, it should take the oldest compatible API version
-	*/
-	private static final String PROFILE_FIELDS = "?fields=id,name,picture,age_range,birthday,email,first_name,last_name,gender,location,locale";
-	private static final String PROFILE_URL = "https://graph.facebook.com/me" + PROFILE_FIELDS;
-	private static final String CONTACTS_URL = "https://graph.facebook.com/me/friends";
-	private static final String UPDATE_STATUS_URL = "https://graph.facebook.com/me/feed";
-	private static final String PROFILE_IMAGE_URL = "http://graph.facebook.com/%1$s/picture";
+
+	public static final String FB_API_VERSION = "v2.7";
+	public static final String FB_API_URL = "https://graph.facebook.com/" + FB_API_VERSION;
+	private static final String PROFILE_URL = FB_API_URL + "/me?fields=id,name,picture,age_range,birthday,email,first_name,last_name,gender,location,locale";
+	private static final String CONTACTS_URL = FB_API_URL + "/me/friends";
+	private static final String UPDATE_STATUS_URL = FB_API_URL + "/me/feed";
+	private static final String PROFILE_IMAGE_URL = FB_API_URL + "/%1$s/picture";
 	private static final String PUBLIC_PROFILE_URL = "http://www.facebook.com/profile.php?id=";
-	private static final String IMAGE_UPLOAD_URL = "https://graph.facebook.com/me/photos";
+	private static final String IMAGE_UPLOAD_URL = FB_API_URL + "/me/photos";
 	private static final Map<String, String> ENDPOINTS;
 	private final Log LOG = LogFactory.getLog(FacebookImpl.class);
 
@@ -95,9 +92,9 @@ public class FacebookImpl extends AbstractProvider {
 	static {
 		ENDPOINTS = new HashMap<String, String>();
 		ENDPOINTS.put(Constants.OAUTH_AUTHORIZATION_URL,
-				"https://graph.facebook.com/oauth/authorize");
+				FB_API_URL + "/oauth/authorize");
 		ENDPOINTS.put(Constants.OAUTH_ACCESS_TOKEN_URL,
-				"https://graph.facebook.com/oauth/access_token");
+				FB_API_URL + "/oauth/access_token");
 	}
 
 	/**


### PR DESCRIPTION
This pull request...

 * Introduces global constants `FB_API_VERSION` and `FB_API_URL`.
 * Set `FB_API_VERSION` to `"v2.7"`.
 * Includes a fix #82