### PR TITLE
Made GitHub API Endpoint configurable through oauth custom properties

### DIFF
--- a/socialauth/src/main/java/org/brickred/socialauth/provider/GitHubImpl.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/provider/GitHubImpl.java
@@ -60,7 +60,6 @@ import org.json.JSONObject;
 public class GitHubImpl extends AbstractProvider {
 
 	private static final long serialVersionUID = -3529658778980357392L;
-	private static final String PROFILE_URL = "https://api.github.com/user";
 	private static final Map<String, String> ENDPOINTS;
 	private final Log LOG = LogFactory.getLog(this.getClass());
 
@@ -81,6 +80,8 @@ public class GitHubImpl extends AbstractProvider {
 				"https://github.com/login/oauth/authorize");
 		ENDPOINTS.put(Constants.OAUTH_ACCESS_TOKEN_URL,
 				"https://github.com/login/oauth/access_token");
+		ENDPOINTS.put(Constants.API_URL,
+				"https://api.github.com");
 	}
 
 	/**
@@ -111,6 +112,17 @@ public class GitHubImpl extends AbstractProvider {
 		} else {
 			config.setAccessTokenUrl(ENDPOINTS
 					.get(Constants.OAUTH_ACCESS_TOKEN_URL));
+		}
+		// Get GitHub API_URL from custom properties
+		if (config.getCustomProperties() != null) {
+			Map<String, String> properties = config.getCustomProperties();
+			if (properties.get(Constants.API_URL) != null) {
+				ENDPOINTS.put(Constants.API_URL,
+						config.getCustomProperties().get(Constants.API_URL));
+			} else {
+				properties.put(Constants.API_URL, ENDPOINTS.get(Constants.API_URL));
+				config.setCustomProperties(properties);
+			}
 		}
 
 		authenticationStrategy = new OAuth2(config, ENDPOINTS);
@@ -151,11 +163,11 @@ public class GitHubImpl extends AbstractProvider {
 		String presp;
 
 		try {
-			Response response = authenticationStrategy.executeFeed(PROFILE_URL);
+			Response response = authenticationStrategy.executeFeed(ENDPOINTS.get(Constants.API_URL) + "/user");
 			presp = response.getResponseBodyAsString(Constants.ENCODING);
 		} catch (Exception e) {
 			throw new SocialAuthException("Error while getting profile from "
-					+ PROFILE_URL, e);
+					+ ENDPOINTS.get(Constants.API_URL) + "/user", e);
 		}
 		try {
 			LOG.debug("User Profile : " + presp);

--- a/socialauth/src/main/java/org/brickred/socialauth/util/Constants.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/util/Constants.java
@@ -113,6 +113,11 @@ public interface Constants {
 	public static final String REFRESH_TOKEN_URL = "refreshTokenURL";
 
 	/**
+	 * API URl (used for GitHub enterprise connection)
+	 */
+	public static final String API_URL = "apiURL";
+
+	/**
 	 * token expires string
 	 */
 	public static final String EXPIRES = "expires";


### PR DESCRIPTION
Regarding #93 I made the API Url for GitHub configurable via OAuth custom properties. This enabled the socialauth sdk to be used with an enterprise GitHub server.

Example config:

```
api.github.com.consumer_key = githubApplicationKey
api.github.com.consumer_secret = githubApplicationSecret
api.github.com.authentication_url = https://enterprise.domain.com/login/oauth/authorize
api.github.com.access_token_url = https://enterprise.domain.com/login/oauth/access_token
api.github.com.custom.apiURL = https://enterprise.domain.com/api/v3
```
