### PR TITLE
Bump up Facebook API to 2.10

### DIFF
--- a/socialauth/src/main/java/org/brickred/socialauth/provider/FacebookImpl.java
+++ b/socialauth/src/main/java/org/brickred/socialauth/provider/FacebookImpl.java
@@ -65,7 +65,7 @@ import org.json.JSONObject;
 public class FacebookImpl extends AbstractProvider {
 	private static final long serialVersionUID = 8644510564735754296L;
 
-	public static final String FB_API_VERSION = "v2.7";
+	public static final String FB_API_VERSION = "v2.10";
 	public static final String FB_API_URL = "https://graph.facebook.com/" + FB_API_VERSION;
 	private static final String PROFILE_URL = FB_API_URL + "/me?fields=id,name,picture,age_range,birthday,email,first_name,last_name,gender,location,locale";
 	private static final String CONTACTS_URL = FB_API_URL + "/me/friends";


### PR DESCRIPTION
Because Facebook API is tend to quickly deprecated, it is better to keep up the recent version.

From 2.7 to 2.10, there seems no notable deprecation, and this pull request works fine for my project. It is unfortunate that socialauth has no test yet.