### PR TITLE
incremented version from 4.14 to 4.15

### DIFF
--- a/env.properties
+++ b/env.properties
@@ -1,6 +1,6 @@
 projects.path=.
-sdk.version=4.14
-socialauth.core.version=4.14
+sdk.version=4.15
+socialauth.core.version=4.15
 socialauth.filter.version=2.4
 socialauth.spring.version=2.6
 socialauth.seam.version=2.1

--- a/socialauth/pom.xml
+++ b/socialauth/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.brickred</groupId>
 	<artifactId>socialauth</artifactId>
 	<name>socialauth</name>
-	<version>4.14</version>
+	<version>4.15</version>
 	<description>SocialAuth library</description>
 	<url>http://code.google.com/p/socialauth/</url>
 	<licenses>


### PR DESCRIPTION
I've made this pull request in the hopes of it starting the process of getting the latest version of the socialauth library (jar) deployed to a maven repository.

Version 4.14 can be found at search.maven.org, which was published on 07-Nov-2016: http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.brickred%22%20AND%20a%3A%22socialauth%22

This version is still using version 2.7 of the facbook API, which will be removed by facebook in a few weeks.

The current code in this repository has already been updated to use version version 2.10 of the facebook API.  Those changes are already on the master branch.  However, those changes have not been released/published to the central maven repository.

So, I bumped the version numbers I could find from 4.14 to 4.15.  I did a maven "install", and it did produce jars that are now version 4.15, and pushed them to my local maven repository.  However, I believe someone will have to facilitate the rest of the process of getting the new version to the central maven repository.